### PR TITLE
Adding support for IR debug info

### DIFF
--- a/qir/qat/Apps/CMakeLists.txt
+++ b/qir/qat/Apps/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(qat Qat/Qat.cpp Qat/QatConfig.cpp)
 
 target_link_libraries(qat ${llvm_libs})
-target_link_libraries(qat Logging TransformationRulesPass Rules AllocationManager Commandline Generators Profile Validator ValidationPass GroupingPass)
+target_link_libraries(qat Logging TransformationRulesPass Rules AllocationManager Commandline Generators Profile Validator ValidationPass GroupingPass ModuleLoader)

--- a/qir/qat/CMakeLists.txt
+++ b/qir/qat/CMakeLists.txt
@@ -14,6 +14,9 @@ microsoft_add_library_tests(Profile GroupingPass)
 microsoft_add_library(Validator)
 target_link_libraries(Validator PRIVATE Logging)
 
+microsoft_add_library(ModuleLoader)
+
+
 microsoft_add_library_tests(Validator  Rules TransformationRulesPass AllocationManager Commandline Generators Validator ValidationPass Logging GroupingPass)
 microsoft_add_library(ValidationPass Logging)
 

--- a/qir/qat/Llvm/Llvm.hpp
+++ b/qir/qat/Llvm/Llvm.hpp
@@ -33,6 +33,8 @@
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/IPO/Inliner.h"
+#include "llvm/Transforms/Instrumentation.h"
+#include "llvm/Transforms/Scalar/LoopUnrollPass.h"
 #include "llvm/Transforms/Scalar/Reassociate.h"
 #include "llvm/Transforms/Scalar/SCCP.h"
 #include "llvm/Transforms/Scalar/SimplifyCFG.h"
@@ -41,11 +43,17 @@
 #include "llvm/Transforms/Utils/Mem2Reg.h"
 
 // Building
+#include "llvm/IR/AssemblyAnnotationWriter.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Constants.h"
+#include "llvm/IR/DIBuilder.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/DebugInfo.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstVisitor.h"
+#include "llvm/IR/Instruction.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Type.h"
@@ -53,9 +61,12 @@
 
 // Reader tool
 #include "llvm/IRReader/IRReader.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FormattedStream.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/SourceMgr.h"
-#include "llvm/Transforms/IPO/Inliner.h"
-#include "llvm/Transforms/Scalar/LoopUnrollPass.h"
+#include "llvm/Support/ToolOutputFile.h"
 
 // Profiles
 #include "llvm/LinkAllPasses.h"

--- a/qir/qat/ModuleLoader/DebugInfoUpdater.cpp
+++ b/qir/qat/ModuleLoader/DebugInfoUpdater.cpp
@@ -1,0 +1,194 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "ModuleLoader/DebugInfoUpdater.hpp"
+
+#include "Llvm/Llvm.hpp"
+#include "ModuleLoader/DebugTable.hpp"
+
+namespace microsoft {
+namespace quantum {
+
+DebugInfoUpdater::DebugInfoUpdater(DebugTablePtr const &debug_info, Module &module,
+                                   StringRef const &directory, StringRef const &filename)
+  : debug_info_{debug_info}
+  , module_{module}
+  , builder_(module)
+{
+  file_unit_ = builder_.createFile(filename, directory);
+  compile_unit_ =
+      builder_.createCompileUnit(llvm::dwarf::DW_LANG_C, file_unit_, "qat", false, "", 0);
+}
+
+void DebugInfoUpdater::update()
+{
+  finder_.processModule(module_);
+  visit(&module_);
+  builder_.finalize();
+}
+
+llvm::DISubroutineType *DebugInfoUpdater::createFunctionType(Function const *function)
+{
+  llvm::SmallVector<llvm::Metadata *, 4> parameters;
+  llvm::DIType                          *return_type = getOrCreateType(function->getReturnType());
+  parameters.push_back(return_type);
+
+  for (auto const &arg : function->args())
+  {
+    parameters.push_back(getOrCreateType(arg.getType()));
+  }
+
+  auto params_array = builder_.getOrCreateTypeArray(parameters);
+  return builder_.createSubroutineType(params_array);
+}
+
+llvm::DIType *DebugInfoUpdater::getType(llvm::Type *type)
+{
+
+  auto it = type_debug_info_.find(type);
+  if (it != type_debug_info_.end())
+  {
+    return it->second;
+  }
+
+  return nullptr;
+}
+
+llvm::DIType *DebugInfoUpdater::createVoidType(llvm::Type *type)
+{
+  auto ret               = builder_.createUnspecifiedType("void");
+  type_debug_info_[type] = ret;
+  return ret;
+}
+
+llvm::DIType *DebugInfoUpdater::createPointerType(llvm::Type *type)
+{
+  auto pointee_type = type->getPointerElementType();
+  auto element_type = getOrCreateType(pointee_type);
+  auto ret          = builder_.createPointerType(element_type, 64);
+
+  type_debug_info_[type] = ret;
+  return ret;
+}
+
+llvm::DIType *DebugInfoUpdater::createOpaqueType(llvm::Type *type)
+{
+  auto ret               = builder_.createUnspecifiedType("opaque");
+  type_debug_info_[type] = ret;
+  return ret;
+}
+
+llvm::DIType *DebugInfoUpdater::getOrCreateType(llvm::Type *type)
+{
+  DIType *di_type = getType(type);
+  if (di_type != nullptr)
+  {
+    return di_type;
+  }
+
+  if (type->isVoidTy())
+  {
+    return createVoidType(type);
+  }
+
+  if (type->isStructTy() || type->isArrayTy())
+  {
+    // TODO(tfr): Consider more comprehensive support for structs and arrays
+    return createOpaqueType(type);
+  }
+
+  if (type->isPointerTy())
+  {
+    return createPointerType(type);
+  }
+
+  // Otherwise, we deal with a primitive type
+  auto encoding = llvm::dwarf::DW_ATE_signed;
+
+  if (type->isIntegerTy())
+  {
+    encoding = llvm::dwarf::DW_ATE_unsigned;
+  }
+  else if (type->isFloatingPointTy())
+  {
+    encoding = llvm::dwarf::DW_ATE_float;
+  }
+
+  auto ret = builder_.createBasicType("PrimitiveType", type->getPrimitiveSizeInBits(), encoding);
+
+  type_debug_info_[type] = ret;
+  return ret;
+}
+
+void DebugInfoUpdater::visitFunction(Function &function)
+{
+  if (function.isDeclaration() ||
+      function_debug_info_.find(&function) != function_debug_info_.end())
+  {
+    return;
+  }
+
+  auto position      = debug_info_->getPosition(&function);
+  auto program_flags = llvm::DISubprogram::SPFlagDefinition;
+
+  if (function.hasPrivateLinkage() || function.hasInternalLinkage())
+  {
+    program_flags |= llvm::DISubprogram::SPFlagLocalToUnit;
+  }
+
+  auto subprogram = builder_.createFunction(file_unit_, function.getName(), StringRef(), file_unit_,
+                                            position.line, createFunctionType(&function),
+                                            position.line, llvm::DINode::FlagZero, program_flags);
+  function.setSubprogram(subprogram);
+
+  function_debug_info_[&function] = subprogram;
+}
+
+void DebugInfoUpdater::visitInstruction(Instruction &instr)
+{
+  auto position = debug_info_->getPosition(&instr);
+  if (position)
+  {
+    auto location = instr.getDebugLoc();
+
+    // Copying scope and inlined at if possible
+    llvm::DILocalScope *scope{nullptr};
+    llvm::DILocation   *inlined_at{nullptr};
+    if (location)
+    {
+      scope      = location->getScope();
+      inlined_at = location->getInlinedAt();
+    }
+    else
+    {
+      auto block    = instr.getParent();
+      auto function = block->getParent();
+      auto it       = function_debug_info_.find(function);
+
+      // Sanity check
+      if (it == function_debug_info_.end())
+      {
+        throw std::runtime_error(
+            "Could not find parent function - this is not supposed to happen.");
+      }
+
+      auto subprogram = it->second;
+      scope           = subprogram;
+    }
+
+    // Sanity check
+    if (scope == nullptr)
+    {
+      throw std::runtime_error("Could not determine scope - this is not supposed to happen.");
+    }
+
+    // Updating the debug location
+    auto new_debug_loc = llvm::DebugLoc(llvm::DILocation::get(module_.getContext(), position.line,
+                                                              position.column, scope, inlined_at));
+
+    instr.setDebugLoc(new_debug_loc);
+  }
+}
+
+}  // namespace quantum
+}  // namespace microsoft

--- a/qir/qat/ModuleLoader/DebugInfoUpdater.hpp
+++ b/qir/qat/ModuleLoader/DebugInfoUpdater.hpp
@@ -1,0 +1,58 @@
+#pragma once
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "Llvm/Llvm.hpp"
+#include "ModuleLoader/DebugTable.hpp"
+
+namespace microsoft {
+namespace quantum {
+
+class DebugInfoUpdater : public llvm::InstVisitor<DebugInfoUpdater>
+{
+public:
+  using DIBuilder   = llvm::DIBuilder;
+  using DataLayout  = llvm::DataLayout;
+  using Module      = llvm::Module;
+  using Function    = llvm::Function;
+  using Instruction = llvm::Instruction;
+  using DIType      = llvm::DIType;
+  using StringRef   = llvm::StringRef;
+
+  DebugInfoUpdater(DebugTablePtr const &debug_info, Module &module, StringRef const &directory,
+                   StringRef const &filename);
+
+  void update();
+
+  // Visitor implementation
+  //
+
+  void visitFunction(Function &function);
+  void visitInstruction(Instruction &instr);
+
+protected:
+  // Creating and getting types
+  //
+
+  llvm::DISubroutineType *createFunctionType(Function const *function);
+  DIType                 *createVoidType(llvm::Type *type);
+  DIType                 *createPointerType(llvm::Type *type);
+  DIType                 *createOpaqueType(llvm::Type *type);
+  DIType                 *getOrCreateType(llvm::Type *type);
+  DIType                 *getType(llvm::Type *type);
+
+public:
+  DebugTablePtr         debug_info_{nullptr};
+  llvm::Module         &module_;
+  llvm::DIBuilder       builder_;
+  llvm::DebugInfoFinder finder_{};
+
+  llvm::DICompileUnit *compile_unit_;
+  llvm::DIFile        *file_unit_;
+
+  llvm::ValueMap<llvm::Function const *, llvm::DISubprogram *> function_debug_info_{};
+  llvm::DenseMap<llvm::Type const *, llvm::DIType *>           type_debug_info_{};
+};
+
+}  // namespace quantum
+}  // namespace microsoft

--- a/qir/qat/ModuleLoader/DebugTable.cpp
+++ b/qir/qat/ModuleLoader/DebugTable.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "ModuleLoader/DebugTable.hpp"
+
+#include "Llvm/Llvm.hpp"
+
+#include <memory>
+
+namespace microsoft {
+namespace quantum {
+
+DebugTable::DebugTablePtr DebugTable::create()
+{
+  DebugTablePtr ret;
+  ret.reset(new DebugTable());
+  return ret;
+}
+
+void DebugTable::printInfoComment(Value const &value, llvm::formatted_raw_ostream &outstream)
+{
+  registerValuePosition(&value, outstream);
+}
+
+void DebugTable::emitBasicBlockStartAnnot(BasicBlock const            *block,
+                                          llvm::formatted_raw_ostream &outstream)
+{
+  registerValuePosition(block, outstream);
+}
+
+void DebugTable::emitFunctionAnnot(Function const *function, llvm::formatted_raw_ostream &outstream)
+{
+  registerValuePosition(function, outstream);
+}
+
+DebugTable::Position DebugTable::getPosition(Value const *value) const
+{
+  auto it = positions_.find(value);
+  if (it != positions_.end())
+  {
+    return it->second;
+  }
+
+  return Position::InvalidPosition();
+}
+
+void DebugTable::registerModule(StringRef const &filename, Module const *module)
+{
+  current_filename_ = filename;
+  llvm::raw_null_ostream dummy{};
+  module->print(dummy, this);
+}
+
+}  // namespace quantum
+}  // namespace microsoft

--- a/qir/qat/ModuleLoader/DebugTable.hpp
+++ b/qir/qat/ModuleLoader/DebugTable.hpp
@@ -1,0 +1,78 @@
+#pragma once
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#include "Llvm/Llvm.hpp"
+
+#include <memory>
+#include <unordered_map>
+
+namespace microsoft {
+namespace quantum {
+
+class DebugTable : public llvm::AssemblyAnnotationWriter
+{
+public:
+  struct Position
+  {
+    // TODO(tfr): merge this with the position defined in LogCollection
+    using StringRef = llvm::StringRef;
+    enum
+    {
+      INVALID_POSITION = -1
+    };
+
+    operator bool() const
+    {
+      return line != INVALID_POSITION && column != INVALID_POSITION;
+    }
+
+    static Position InvalidPosition()
+    {
+      return {"", INVALID_POSITION, INVALID_POSITION};
+    }
+
+    StringRef filename{""};
+    int64_t   line{0};
+    int64_t   column{0};
+  };
+
+  using StringRef     = llvm::StringRef;
+  using BasicBlock    = llvm::BasicBlock;
+  using Function      = llvm::Function;
+  using Value         = llvm::Value;
+  using Module        = llvm::Module;
+  using Positions     = std::unordered_map<Value const *, Position>;
+  using DebugTablePtr = std::shared_ptr<DebugTable>;
+
+  static DebugTablePtr create();
+
+  void printInfoComment(Value const &value, llvm::formatted_raw_ostream &outstream) override;
+  void emitBasicBlockStartAnnot(BasicBlock const            *block,
+                                llvm::formatted_raw_ostream &outstream) override;
+  void emitFunctionAnnot(Function const *function, llvm::formatted_raw_ostream &outstream) override;
+  Position getPosition(Value const *value) const;
+  void     registerModule(StringRef const &filename, Module const *module);
+
+private:
+  Positions positions_;
+  StringRef current_filename_{};
+
+  DebugTable() = default;
+  void registerValuePosition(Value const *value, llvm::formatted_raw_ostream &outstream)
+  {
+    outstream.flush();
+
+    Position pos;
+    pos.filename = current_filename_;
+    pos.line     = outstream.getLine() + 1;
+    pos.column   = outstream.getColumn() + 1;
+
+    positions_.insert(std::make_pair(value, std::move(pos)));
+  }
+};
+
+using DebugTablePtr = DebugTable::DebugTablePtr;
+
+}  // namespace quantum
+}  // namespace microsoft

--- a/qir/qat/ModuleLoader/ModuleLoader.hpp
+++ b/qir/qat/ModuleLoader/ModuleLoader.hpp
@@ -2,132 +2,167 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#include "Llvm/Llvm.hpp"
+#include "ModuleLoader/DebugInfoUpdater.hpp"
+#include "ModuleLoader/DebugTable.hpp"
 #include "QatTypes/QatTypes.hpp"
 #include "RemoveDisallowedAttributesPass/RemoveDisallowedAttributesPass.hpp"
 
-#include "Llvm/Llvm.hpp"
+namespace microsoft {
+namespace quantum {
 
-namespace microsoft
+class ModuleLoader
 {
-namespace quantum
-{
+public:
+  using Module       = llvm::Module;
+  using Linker       = llvm::Linker;
+  using SMDiagnostic = llvm::SMDiagnostic;
 
-    class ModuleLoader
+  explicit ModuleLoader(Module *final_module)
+    : final_module_{final_module}
+    , linker_{*final_module}
+    , debug_table_{DebugTable::create()}
+  {}
+
+  bool addModule(std::unique_ptr<Module> &&module, String const &filename = "unknown")
+  {
+    if (llvm::verifyModule(*module, &llvm::errs()))
     {
-      public:
-        using Module       = llvm::Module;
-        using Linker       = llvm::Linker;
-        using SMDiagnostic = llvm::SMDiagnostic;
+      llvm::errs() << filename << ": "
+                   << "input module is broken!\n";
+      return false;
+    }
 
-        explicit ModuleLoader(Module* final_module)
-          : final_module_{final_module}
-          , linker_{*final_module}
+    return !linker_.linkInModule(std::move(module), Linker::Flags::None);
+  }
 
-        {
-        }
+  bool addIrFile(String input_file)
+  {
+    bool override_debug_symbols = true;
 
-        bool addModule(std::unique_ptr<Module>&& module, String const& filename = "unknown")
-        {
-            if (llvm::verifyModule(*module, &llvm::errs()))
-            {
-                llvm::errs() << filename << ": "
-                             << "input module is broken!\n";
-                return false;
-            }
+    // Converting to absolute path
+    llvm::SmallVector<char, 256> input_vec;
+    input_vec.assign(input_file.begin(), input_file.end());
+    llvm::sys::fs::make_absolute(input_vec);
+    input_file.resize(input_vec.size());
+    uint64_t i = 0;
+    for (auto &s : input_vec)
+    {
+      input_file[i++] = s;
+    }
 
-            return !linker_.linkInModule(std::move(module), Linker::Flags::None);
-        }
+    // Loading module
+    SMDiagnostic            err;
+    std::unique_ptr<Module> module =
+        llvm::parseIRFile(input_file, err, final_module_->getContext());
+    if (!module)
+    {
+      llvm::errs() << "Failed to load " << input_file << "\n";
+      return false;
+    }
 
-        bool addIrFile(String const& filename)
-        {
+    // Registering all debug info
+    auto directory = llvm::sys::path::parent_path(input_file);
+    auto filename  = llvm::sys::path::filename(input_file);
 
-            // Loading module
-            SMDiagnostic            err;
-            std::unique_ptr<Module> module = llvm::parseIRFile(filename, err, final_module_->getContext());
-            if (!module)
-            {
-                llvm::errs() << "Failed to load " << filename << "\n";
-                return false;
-            }
+    debug_table_->registerModule(input_file, module.get());
 
-            // Transforming module
-            SingleModuleTransformation transformation;
-            if (!transformation.apply(module.get()))
-            {
-                llvm::errs() << "Failed to transform " << filename << "\n";
-                return false;
-            }
+    // Whether or not to override debug symbols
+    if (override_debug_symbols)
+    {
+      // Debug info
+      llvm::StripDebugInfo(*module.get());
 
-            // Linking
-            return addModule(std::move(module), filename);
-        }
+      // Adding debug versioning
+      auto debug_version_key = "Debug Info Version";
+      if (!module->getModuleFlag(debug_version_key))
+      {
+        module->addModuleFlag(llvm::Module::Warning, debug_version_key,
+                              llvm::DEBUG_METADATA_VERSION);
+      }
 
-      private:
-        Module* final_module_;
-        Linker  linker_;
+      // Update with debug information
+      DebugInfoUpdater updater(debug_table_, *module.get(), directory, filename);
+      updater.update();
+    }
 
-        // Single Module Transformation
-        //
+    // Transforming module
+    SingleModuleTransformation transformation;
+    if (!transformation.apply(module.get()))
+    {
+      llvm::errs() << "Failed to transform " << input_file << "\n";
+      return false;
+    }
 
-        class SingleModuleTransformation
-        {
-          public:
-            using PassBuilder             = llvm::PassBuilder;
-            using OptimizationLevel       = PassBuilder::OptimizationLevel;
-            using FunctionAnalysisManager = llvm::FunctionAnalysisManager;
+    // Linking
+    return addModule(std::move(module), input_file);
+  }
 
-            explicit SingleModuleTransformation(
-                OptimizationLevel const& optimization_level = OptimizationLevel::O0,
-                bool                     debug              = false)
-              : loop_analysis_manager_{debug}
-              , function_analysis_manager_{debug}
-              , gscc_analysis_manager_{debug}
-              , module_analysis_manager_{debug}
-              , optimization_level_{optimization_level}
-              , debug_{debug}
-            {
+private:
+  Module       *final_module_;
+  Linker        linker_;
+  DebugTablePtr debug_table_{nullptr};
 
-                pass_builder_.registerModuleAnalyses(module_analysis_manager_);
-                pass_builder_.registerCGSCCAnalyses(gscc_analysis_manager_);
-                pass_builder_.registerFunctionAnalyses(function_analysis_manager_);
-                pass_builder_.registerLoopAnalyses(loop_analysis_manager_);
+  // Single Module Transformation
+  //
 
-                pass_builder_.crossRegisterProxies(
-                    loop_analysis_manager_, function_analysis_manager_, gscc_analysis_manager_,
-                    module_analysis_manager_);
+  class SingleModuleTransformation
+  {
+  public:
+    using PassBuilder             = llvm::PassBuilder;
+    using OptimizationLevel       = PassBuilder::OptimizationLevel;
+    using FunctionAnalysisManager = llvm::FunctionAnalysisManager;
 
-                module_pass_manager_.addPass(RemoveDisallowedAttributesPass());
-            }
+    explicit SingleModuleTransformation(
+        OptimizationLevel const &optimization_level = OptimizationLevel::O0, bool debug = false)
+      : loop_analysis_manager_{debug}
+      , function_analysis_manager_{debug}
+      , gscc_analysis_manager_{debug}
+      , module_analysis_manager_{debug}
+      , optimization_level_{optimization_level}
+      , debug_{debug}
+    {
 
-            bool apply(llvm::Module* module)
-            {
-                module_pass_manager_.run(*module, module_analysis_manager_);
+      pass_builder_.registerModuleAnalyses(module_analysis_manager_);
+      pass_builder_.registerCGSCCAnalyses(gscc_analysis_manager_);
+      pass_builder_.registerFunctionAnalyses(function_analysis_manager_);
+      pass_builder_.registerLoopAnalyses(loop_analysis_manager_);
 
-                if (llvm::verifyModule(*module, &llvm::errs()))
-                {
-                    return false;
-                }
+      pass_builder_.crossRegisterProxies(loop_analysis_manager_, function_analysis_manager_,
+                                         gscc_analysis_manager_, module_analysis_manager_);
 
-                return true;
-            }
+      module_pass_manager_.addPass(RemoveDisallowedAttributesPass());
+    }
 
-            bool isDebugMode() const
-            {
-                return debug_;
-            }
+    bool apply(llvm::Module *module)
+    {
+      module_pass_manager_.run(*module, module_analysis_manager_);
 
-          private:
-            llvm::PassBuilder             pass_builder_;
-            llvm::LoopAnalysisManager     loop_analysis_manager_;
-            llvm::FunctionAnalysisManager function_analysis_manager_;
-            llvm::CGSCCAnalysisManager    gscc_analysis_manager_;
-            llvm::ModuleAnalysisManager   module_analysis_manager_;
+      if (llvm::verifyModule(*module, &llvm::errs()))
+      {
+        return false;
+      }
 
-            llvm::ModulePassManager module_pass_manager_{};
-            OptimizationLevel       optimization_level_{};
-            bool                    debug_{false};
-        };
-    };
+      return true;
+    }
 
-} // namespace quantum
-} // namespace microsoft
+    bool isDebugMode() const
+    {
+      return debug_;
+    }
+
+  private:
+    llvm::PassBuilder             pass_builder_;
+    llvm::LoopAnalysisManager     loop_analysis_manager_;
+    llvm::FunctionAnalysisManager function_analysis_manager_;
+    llvm::CGSCCAnalysisManager    gscc_analysis_manager_;
+    llvm::ModuleAnalysisManager   module_analysis_manager_;
+
+    llvm::ModulePassManager module_pass_manager_{};
+    OptimizationLevel       optimization_level_{};
+    bool                    debug_{false};
+  };
+};
+
+}  // namespace quantum
+}  // namespace microsoft


### PR DESCRIPTION
Using
```c++
#include <iostream>
#include <vector>

int main()
{
  std::vector<int> x;
  std::cout << "Hello world" << std::endl;
  x[10299] = x[10299 * 2777] + 2;
  std::cout << "X[10299] = " << x[10299] << std::endl;
  return 0;
}
```
We create an IR and use QAT to add debug info
```
% clang++ -O3 -c -S -emit-llvm segfault.cpp
% qat -S segfault.ll > with_debug.ll
% mkdir -p bin
% llc -filetype=obj -o bin/testprog.o with_debug.ll
% clang++ -g -O1 bin/testprog.o -o bin/testprog
% lldb bin/testprog
```
Executing the program in the debugger we now see that the IR file is referred to when the segfault is happening:
```
(lldb) target create "bin/testprog"
Current executable set to '/Users/tfr/Documents/TestArea/LLVMIR/bin/testprog' (x86_64).
(lldb) r
Process 88015 launched: '/Users/tfr/Documents/TestArea/LLVMIR/bin/testprog' (x86_64)
Hello world
Process 88015 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x6d1a00c)
    frame #0: 0x0000000100003a4e testprog`main at segfault.ll:72:75
   69  	  call void @llvm.lifetime.end.p0i8(i64 8, i8* nonnull %11) #9
   70  	  %24 = call nonnull align 8 dereferenceable(8) %"class.std::__1::basic_ostream"* @_ZNSt3__113basic_ostreamIcNS_11char_traitsIcEEE3putEc(%"class.std::__1::basic_ostream"* nonnull %3, i8 signext %20)
   71  	  %25 = call nonnull align 8 dereferenceable(8) %"class.std::__1::basic_ostream"* @_ZNSt3__113basic_ostreamIcNS_11char_traitsIcEEE5flushEv(%"class.std::__1::basic_ostream"* nonnull %3)
-> 72  	  %26 = load i32, i32* inttoptr (i64 114401292 to i32*), align 4, !tbaa !6
   73  	  %27 = add nsw i32 %26, 2
   74  	  store i32 %27, i32* inttoptr (i64 41196 to i32*), align 4, !tbaa !6
   75  	  %28 = call nonnull align 8 dereferenceable(8) %"class.std::__1::basic_ostream"* @_ZNSt3__124__put_character_sequenceIcNS_11char_traitsIcEEEERNS_13basic_ostreamIT_T0_EES7_PKS4_m(%"class.std::__1::basic_ostream"* nonnull align 8 dereferenceable(8) @_ZNSt3__14coutE, i8* getelementptr inbounds ([12 x i8], [12 x i8]* @.str.1, i64 0, i64 0), i64 11)
(lldb)
```