### PR TITLE
Add lower switch pass in static resource

### DIFF
--- a/qir/qat/Generators/ProfileGenerator.cpp
+++ b/qir/qat/Generators/ProfileGenerator.cpp
@@ -301,6 +301,7 @@ void ProfileGenerator::setupDefaultComponentPipeline()
                 fpm.addPass(llvm::AggressiveInstCombinePass());
                 fpm.addPass(llvm::SCCPPass());
                 fpm.addPass(llvm::SimplifyCFGPass());
+                fpm.addPass(llvm::LowerSwitchPass());
             }
 
             fpm.addPass(ResourceAnnotationPass(cfg, logger));


### PR DESCRIPTION
Since the static resource pass also performs a SimplifyCFG pass, it can have have the side effect of reintroducing switch instructions even after they've been removed by the earlier LowerSwitch pass. This adds LowerSwitch to the set of post id change passes.