### PR TITLE
Add i8* to the list of supported pointer types for provider 7ee0

### DIFF
--- a/qir/qat/ValidationPass/ValidationPassConfiguration.cpp
+++ b/qir/qat/ValidationPass/ValidationPassConfiguration.cpp
@@ -184,7 +184,7 @@ ValidationPassConfiguration ValidationPassConfiguration::fromProfileName(String 
 
         };
         profile.allowlist_pointer_types_ = true;
-        profile.allowed_pointer_types_   = {"Qubit*", "Result*"};
+        profile.allowed_pointer_types_   = {"Qubit*", "Result*", "i8*"};
     }
     else if (name == "provider_b340")
     {


### PR DESCRIPTION
In PR#126 we added functions that receive arguments with type `i8*` to the 7ee0 provider, but this type was not explicitly added to the list of allowed pointer types. This change fixes it.