### PR TITLE
Fix handling of `--allow-any-qis` param

### DIFF
--- a/qir/qat/Passes/ValidationPass/TargetQisConfiguration.cpp
+++ b/qir/qat/Passes/ValidationPass/TargetQisConfiguration.cpp
@@ -41,6 +41,11 @@ bool TargetQisConfiguration::requiresResults() const
     return requires_results_;
 }
 
+bool TargetQisConfiguration::allowAnyQis() const
+{
+    return allow_any_qis_;
+}
+
 TargetQisConfiguration TargetQisConfiguration::fromQirTargetName(String const& name)
 {
     auto target_config = TargetQisConfiguration();

--- a/qir/qat/Passes/ValidationPass/TargetQisConfiguration.hpp
+++ b/qir/qat/Passes/ValidationPass/TargetQisConfiguration.hpp
@@ -28,6 +28,7 @@ class TargetQisConfiguration
     Set const&                    allowedQis() const;
     Set const&                    irreversibleOperations() const;
 
+    bool allowAnyQis() const;
     bool requiresQubits() const;
     bool requiresResults() const;
 

--- a/qir/qat/Passes/ValidationPass/ValidationPass.cpp
+++ b/qir/qat/Passes/ValidationPass/ValidationPass.cpp
@@ -303,7 +303,7 @@ bool ValidationPass::satisfyingExternalCallRequirements()
         for (auto const& k : external_calls_)
         {
             if (allowed_functions.find(k.first) == allowed_functions.end() &&
-                allowed_qis.find(k.first) == allowed_qis.end() && 
+                allowed_qis.find(k.first) == allowed_qis.end() &&
                 !(k.first.rfind("__quantum__qis__", 0) == 0 && qis_config_.allowAnyQis()))
             {
                 logger_->setLlvmHint("");

--- a/qir/qat/Passes/ValidationPass/ValidationPass.cpp
+++ b/qir/qat/Passes/ValidationPass/ValidationPass.cpp
@@ -295,7 +295,7 @@ bool ValidationPass::satisfyingExternalCallRequirements()
 {
     auto ret = true;
 
-    if (profile_config_.allowlistExternalCalls() && !qis_config_.allowAnyQis())
+    if (profile_config_.allowlistExternalCalls())
     {
         auto const& allowed_functions = profile_config_.allowedExternalCallNames();
         auto const& allowed_qis       = qis_config_.allowedQis();
@@ -303,7 +303,8 @@ bool ValidationPass::satisfyingExternalCallRequirements()
         for (auto const& k : external_calls_)
         {
             if (allowed_functions.find(k.first) == allowed_functions.end() &&
-                allowed_qis.find(k.first) == allowed_qis.end())
+                allowed_qis.find(k.first) == allowed_qis.end() && 
+                !(k.first.rfind("__quantum__qis__", 0) == 0 && qis_config_.allowAnyQis()))
             {
                 logger_->setLlvmHint("");
 

--- a/qir/qat/Passes/ValidationPass/ValidationPass.cpp
+++ b/qir/qat/Passes/ValidationPass/ValidationPass.cpp
@@ -295,7 +295,7 @@ bool ValidationPass::satisfyingExternalCallRequirements()
 {
     auto ret = true;
 
-    if (profile_config_.allowlistExternalCalls())
+    if (profile_config_.allowlistExternalCalls() && !qis_config_.allowAnyQis())
     {
         auto const& allowed_functions = profile_config_.allowedExternalCallNames();
         auto const& allowed_qis       = qis_config_.allowedQis();


### PR DESCRIPTION
This channge wires up the internal handling of the `--allow-any-qis` parameter, which was present but not correctly checked before. Now, when the flag is provided, it will override the settings from the loaded adaptor profile and skip checking the qis whitelist, allowing for easier experimentation with new instructions before formally added them to an adaptor profile.