### PR TITLE
Trying smaller devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,11 @@
-FROM mcr.microsoft.com/vscode/devcontainers/universal:linux
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add - && \
-    sudo add-apt-repository "deb https://apt.llvm.org/focal/ llvm-toolchain-focal-13 main" && \
-    sudo apt-get -y update && \
-    sudo apt-get -y remove llvm-10 && \
-    sudo apt-get -y install clang-13 clang-format-13 clang-tidy-13 && \
-    sudo apt autoremove -y && \
-    npm install -g prettier@2.2.1
+FROM ubuntu:focal
+ADD https://apt.llvm.org/llvm-snapshot.gpg.key /llvm-snapshot.gpg.key
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get install -y git gnupg2 software-properties-common cmake python3-pip && \
+    apt-key add /llvm-snapshot.gpg.key && \
+    add-apt-repository "deb https://apt.llvm.org/focal/ llvm-toolchain-focal-13 main" && \
+    apt-get -y update && \
+    apt-get -y install clang-13 clang-format-13 clang-tidy-13 && \
+    apt autoremove -y
 ENV CC=clang-13 CXX=clang++-13

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,13 +14,12 @@
         "python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
         "python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
         "python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
-        },
-    "remoteUser": "codespace",
+    },
     "workspaceMount": "source=${localWorkspaceFolder},target=/home/qat,type=bind,consistency=cached",
     "workspaceFolder": "/home/qat",
     "extensions": [
         "ms-vscode.cpptools",
         "ms-python.python"
     ],
-    "postCreateCommand": "git submodule update --init --recursive && pip install -r /home/qat/requirements.txt"
+    "postCreateCommand": "git config --global --add safe.directory /home/qat && git config --global --add safe.directory /home/qat/vendors/googletest && git config --global --add safe.directory /home/qat/vendors/yaml-cpp && git submodule update --init --recursive && pip install -r /home/qat/requirements.txt"
 }


### PR DESCRIPTION
This updates the devcontainer to use `ubuntu:focal` as the base image, which requires installing a few extra tools but overall is a much smaller resulting image (~1 GB vs ~11 GB with the previous configuration). This makes it a smaller download and lower footprint for both codespaces and local development, with the tradeoff being less software and tooling installed by default.