### PR TITLE
Add disable-straightline-code-requirement option

### DIFF
--- a/qir/qat/Passes/PostTransformValidation/PostTransformValidationPassConfiguration.hpp
+++ b/qir/qat/Passes/PostTransformValidation/PostTransformValidationPassConfiguration.hpp
@@ -17,6 +17,7 @@ class PostTransformValidationPassConfiguration
     void setup(ConfigurationManager& config)
     {
         config.setSectionName("Post transform validation", "");
+        config.addParameter(disable_straightline_code_requirement_, "disable-straightline-code-requirement", "Validate whether only one defined single-block should be present.");
         replace_qubits_on_reset_ = config.getParameter("replace-qubit-on-reset");
         defer_measurements_      = config.getParameter("defer-measurements");
     }

--- a/qir/qat/Passes/PostTransformValidation/PostTransformValidationPassConfiguration.hpp
+++ b/qir/qat/Passes/PostTransformValidation/PostTransformValidationPassConfiguration.hpp
@@ -17,7 +17,9 @@ class PostTransformValidationPassConfiguration
     void setup(ConfigurationManager& config)
     {
         config.setSectionName("Post transform validation", "");
-        config.addParameter(disable_straightline_code_requirement_, "disable-straightline-code-requirement", "Validate whether only one defined single-block should be present.");
+        config.addParameter(
+            disable_straightline_code_requirement_, "disable-straightline-code-requirement",
+            "Validate whether only one defined single-block should be present.");
         replace_qubits_on_reset_ = config.getParameter("replace-qubit-on-reset");
         defer_measurements_      = config.getParameter("defer-measurements");
     }


### PR DESCRIPTION
This change adds a `disable-straightline-code-requirement` option. This new option controls whether QIR should be validated to have just one function implementation with a single block.

Before this change, it the behavior was as if this option was set to `false` by default and only set to `true` if both the `replace-qubit-on-reset` and `defer-measurements` options are set to `true`.