### PR TITLE
Fix reindex after reset, defer measure ordering

### DIFF
--- a/qir/qat/Apps/Qat/QatConfig.cpp
+++ b/qir/qat/Apps/Qat/QatConfig.cpp
@@ -21,7 +21,7 @@ void QatConfig::setup(ConfigurationManager& config)
     config.addParameter(
         adapter_pipeline_,
         {"replacement-linking", "llvm-optimization", "remove-non-entrypoint-functions", "target-qis-mapping",
-         "target-profile-mapping", "straightline-code-requirement", "static-resources", "grouping"},
+         "static-resources", "target-profile-mapping", "straightline-code-requirement", "grouping"},
         "adaptor-pipeline", "Overrides the adaptor pipleline.");
 
     config.addParameter(

--- a/qir/qat/Commandline/ConfigBind.hpp
+++ b/qir/qat/Commandline/ConfigBind.hpp
@@ -36,12 +36,12 @@ template <typename T> class ConfigBind : public IConfigBind
     // Constructors, operators and destructor
     //
 
-    ConfigBind()                  = delete;
-    ConfigBind(ConfigBind const&) = delete;
-    ConfigBind(ConfigBind&&)      = delete;
+    ConfigBind()                             = delete;
+    ConfigBind(ConfigBind const&)            = delete;
+    ConfigBind(ConfigBind&&)                 = delete;
     ConfigBind& operator=(ConfigBind const&) = delete;
-    ConfigBind& operator=(ConfigBind&&) = delete;
-    ~ConfigBind() override              = default;
+    ConfigBind& operator=(ConfigBind&&)      = delete;
+    ~ConfigBind() override                   = default;
 
     /// Constructor to bind value to parameter. This class holds a reference to a variable together
     /// with the name it is expected to have when passed through the parameter parser.
@@ -680,6 +680,7 @@ template <typename T> void ConfigBind<T>::loadYaml(YAML::Node const& node, Strin
 
 template <typename T> void ConfigBind<T>::loadYaml(YAML::Node const& node, StringList& value)
 {
+    value.clear();
     for (auto& v : node[name()])
     {
         value.push_back(v.template as<String>());

--- a/qir/qat/Commandline/ConfigBind.hpp
+++ b/qir/qat/Commandline/ConfigBind.hpp
@@ -681,6 +681,7 @@ template <typename T> void ConfigBind<T>::loadYaml(YAML::Node const& node, Strin
 template <typename T> void ConfigBind<T>::loadYaml(YAML::Node const& node, StringList& value)
 {
     value.clear();
+
     for (auto& v : node[name()])
     {
         value.push_back(v.template as<String>());

--- a/qir/qat/Commandline/ConfigBind.hpp
+++ b/qir/qat/Commandline/ConfigBind.hpp
@@ -36,12 +36,12 @@ template <typename T> class ConfigBind : public IConfigBind
     // Constructors, operators and destructor
     //
 
-    ConfigBind()                             = delete;
-    ConfigBind(ConfigBind const&)            = delete;
-    ConfigBind(ConfigBind&&)                 = delete;
+    ConfigBind()                  = delete;
+    ConfigBind(ConfigBind const&) = delete;
+    ConfigBind(ConfigBind&&)      = delete;
     ConfigBind& operator=(ConfigBind const&) = delete;
-    ConfigBind& operator=(ConfigBind&&)      = delete;
-    ~ConfigBind() override                   = default;
+    ConfigBind& operator=(ConfigBind&&) = delete;
+    ~ConfigBind() override              = default;
 
     /// Constructor to bind value to parameter. This class holds a reference to a variable together
     /// with the name it is expected to have when passed through the parameter parser.

--- a/qir/qat/Passes/StaticResourceComponent/ReplaceQubitOnResetPass.cpp
+++ b/qir/qat/Passes/StaticResourceComponent/ReplaceQubitOnResetPass.cpp
@@ -198,12 +198,6 @@ llvm::PreservedAnalyses ReplaceQubitOnResetPass::run(llvm::Function& function, l
                     new_instr = new llvm::IntToPtrInst(new_index, pointer_type);
                     builder.Insert(new_instr);
 
-                    auto op_as_instr = llvm::dyn_cast<llvm::Instruction>(op);
-                    if (op_as_instr)
-                    {
-                        to_remove.push_back(op_as_instr);
-                    }
-
                     instr.setOperand(static_cast<uint32_t>(i), new_instr);
                     already_replaced.insert(new_instr);
                 }

--- a/targets/target_4bf9.yaml
+++ b/targets/target_4bf9.yaml
@@ -12,9 +12,9 @@ qat:
     - llvm-optimization
     - remove-non-entrypoint-functions
     - target-qis-mapping
+    - static-resources
     - target-profile-mapping
     - straightline-code-requirement
-    - static-resources
     - grouping
   emit-human-readable-llvm: false
   verify-module: true

--- a/targets/target_7ee0.yaml
+++ b/targets/target_7ee0.yaml
@@ -12,9 +12,9 @@ qat:
     - llvm-optimization
     - remove-non-entrypoint-functions
     - target-qis-mapping
+    - static-resources
     - target-profile-mapping
     - straightline-code-requirement
-    - static-resources
     - grouping
   emit-human-readable-llvm: false
   verify-module: true

--- a/targets/target_b340.yaml
+++ b/targets/target_b340.yaml
@@ -77,7 +77,7 @@ adaptor:
     annotate-max-result-index: true
     reindex-qubits: true
     replace-qubit-on-reset: true
-    inline-after-id-change: false
+    inline-after-id-change: true
   grouping:
     separate-circuits: false
 target:

--- a/targets/target_b340.yaml
+++ b/targets/target_b340.yaml
@@ -12,9 +12,9 @@ qat:
     - llvm-optimization
     - remove-non-entrypoint-functions
     - target-qis-mapping
+    - static-resources
     - target-profile-mapping
     - straightline-code-requirement
-    - static-resources
     - grouping
   emit-human-readable-llvm: false
   verify-module: true
@@ -77,7 +77,7 @@ adaptor:
     annotate-max-result-index: true
     reindex-qubits: true
     replace-qubit-on-reset: true
-    inline-after-id-change: true
+    inline-after-id-change: false
   grouping:
     separate-circuits: false
 target:


### PR DESCRIPTION
This change fixes the behavior of the reindex after reset pass, which when run after the defer measurements pass can cause incorrect qubit measurement. Instead of deferring measurement first, which also moves reset calls, the pass ordering now does reset elimination and reindexing first in the default and configured adaptor pipelines.

This also fixes a bug where configuration or cmdline values for adaptor pipeline were incorrectly appended rather than replacing the default values.