### PR TITLE
Include DCE, Global DCE after static-resource pass

### DIFF
--- a/qir/qat/AdaptorFactory/QirAdaptorFactory.cpp
+++ b/qir/qat/AdaptorFactory/QirAdaptorFactory.cpp
@@ -253,7 +253,7 @@ void QirAdaptorFactory::setupDefaultComponentPipeline()
             // Defining the mapping
             RuleSet rule_set;
             auto    factory = RuleFactory(
-                   rule_set, adaptor.getQubitAllocationManager(), adaptor.getResultAllocationManager(), logger);
+                rule_set, adaptor.getQubitAllocationManager(), adaptor.getResultAllocationManager(), logger);
             factory.usingConfiguration(adaptor.configurationManager().get<TargetQisMappingPassConfiguration>());
 
             // Creating adaptor pass
@@ -341,8 +341,11 @@ void QirAdaptorFactory::setupDefaultComponentPipeline()
                 fpm.addPass(ZExtTransformPass());
             }
 
+            fpm.addPass(llvm::ADCEPass());
             fpm.addPass(ResourceAnnotationPass(cfg, logger));
+
             mpm.addPass(FunctionToModule(std::move(fpm)));
+            mpm.addPass(llvm::GlobalDCEPass());
         });
 
     registerAdaptorComponent<GroupingPassConfiguration>(

--- a/qir/qat/AdaptorFactory/QirAdaptorFactory.cpp
+++ b/qir/qat/AdaptorFactory/QirAdaptorFactory.cpp
@@ -253,7 +253,7 @@ void QirAdaptorFactory::setupDefaultComponentPipeline()
             // Defining the mapping
             RuleSet rule_set;
             auto    factory = RuleFactory(
-                rule_set, adaptor.getQubitAllocationManager(), adaptor.getResultAllocationManager(), logger);
+                   rule_set, adaptor.getQubitAllocationManager(), adaptor.getResultAllocationManager(), logger);
             factory.usingConfiguration(adaptor.configurationManager().get<TargetQisMappingPassConfiguration>());
 
             // Creating adaptor pass

--- a/qir/qat/AdaptorFactory/QirAdaptorFactory.cpp
+++ b/qir/qat/AdaptorFactory/QirAdaptorFactory.cpp
@@ -338,12 +338,11 @@ void QirAdaptorFactory::setupDefaultComponentPipeline()
                 fpm.addPass(llvm::SCCPPass());
                 fpm.addPass(llvm::SimplifyCFGPass());
                 fpm.addPass(llvm::LowerSwitchPass());
+                fpm.addPass(llvm::ADCEPass());
                 fpm.addPass(ZExtTransformPass());
             }
 
-            fpm.addPass(llvm::ADCEPass());
             fpm.addPass(ResourceAnnotationPass(cfg, logger));
-
             mpm.addPass(FunctionToModule(std::move(fpm)));
             mpm.addPass(llvm::GlobalDCEPass());
         });


### PR DESCRIPTION
This change updates the static-resources pass to include Dead-Code Elimination and Global Dead Code Elimination as part of cleaning up after the qubit identifiers have been updated.