### PR TITLE
Fix outline layout in docs and typos in docs

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,6 +1,6 @@
 # For more info on markdown lint configurations, see also
 # https://github.com/DavidAnson/markdownlint/blob/main/schema/.markdownlint.yaml
-# https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
+# https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md
 
 default: true
 line-length:
@@ -31,3 +31,12 @@ no-inline-html:
 # Allow exclamation mark and question marks in headings
 no-emphasis-as-heading:
   punctuation: ".,;:。，；：！"
+
+# MD007/ul-indent - Unordered list indentation
+MD007:
+  # Spaces for indent
+  indent: 4
+  # Whether to indent the first level of the list
+  start_indented: false
+  # Spaces for first level indent (when start_indented is set)
+  start_indent: 2

--- a/docs/src/DeveloperGuide/CodeQuality.md
+++ b/docs/src/DeveloperGuide/CodeQuality.md
@@ -4,7 +4,7 @@
 
 Before making a pull request with changes to this library, please ensure that
 style checks passes, that the code compiles, unit test passes and that there are
-no erros found by the static analyser.
+no errors found by the static analyser.
 
 For code formatting and linting, we use [Trunk](https://trunk.io) to manage this
 process. To install trunk run

--- a/docs/src/DeveloperGuide/LogicSeparation.md
+++ b/docs/src/DeveloperGuide/LogicSeparation.md
@@ -158,19 +158,19 @@ function arguments together with the return result determine where the call will
 be executed according to following rules:
 
 - Any `void` function location is purely determined by its arguments:
-  - Void functions that only have quantum register types as arguments are
-    classified as pure QPU instructions
-  - Void functions that only have classical register types as arguments are
-    classified as pure CPU instructions
-  - Void functions that takes a mixture are classified as CPU to QPU
-    setup/transport instructions
+    - Void functions that only have quantum register types as arguments are
+      classified as pure QPU instructions
+    - Void functions that only have classical register types as arguments are
+      classified as pure CPU instructions
+    - Void functions that takes a mixture are classified as CPU to QPU
+      setup/transport instructions
 - Any function that returns a quantum register is:
-  - A pure quantum instruction if all of the function arguments are quantum
-    registers
-  - A CPU to QPU setup/transport instruction in any other case
+    - A pure quantum instruction if all of the function arguments are quantum
+      registers
+    - A CPU to QPU setup/transport instruction in any other case
 - A function that returns a classical register is:
-  - A pure classical instruction if all of the arguments are classical registers
-  - A QPU to CPU result/transport instruction in any other case
+    - A pure classical instruction if all of the arguments are classical registers
+    - A QPU to CPU result/transport instruction in any other case
 
 ### Pass definition
 

--- a/docs/src/DeveloperGuide/WritingAdaptor.md
+++ b/docs/src/DeveloperGuide/WritingAdaptor.md
@@ -267,4 +267,4 @@ registerAdaptorComponent<InlinerConfig>(
 Recompile QAT and the adaptor is now QAT native. The final step is adding the
 adaptor to the pipeline: Open `qat/qir/Apps/Qat/QatConfig.cpp` and locate the
 line starting with `config.addParameter(adapter_pipeline_,`. Add the adaptor at
-the apppropriate place. This will make the adaptor loaded by default.
+the appropriate place. This will make the adaptor loaded by default.

--- a/docs/src/QuickStart/index.md
+++ b/docs/src/QuickStart/index.md
@@ -5,7 +5,7 @@ need to follow to build the QIR adaptor tool (QAT). QAT can be built either
 using Bazel or CMake. In the following two sections, we discuss how to build QAT
 using either of these tools. Building on Windows is currently only supported
 [using Bazel](./building-with-bazel.md). The
-[detailed decription of building with Bazel](./building-with-bazel.md) outlines
+[detailed description of building with Bazel](./building-with-bazel.md) outlines
 how to install `bazelisk` and discusses configuration flags. If you already have
 `bazelisk` installed, simply run
 

--- a/docs/src/QuickStart/running-qat.md
+++ b/docs/src/QuickStart/running-qat.md
@@ -54,9 +54,9 @@ Note that rather than using the `-o` option, we redirect the output into the
 output file. This is capture the configuration together with the resulting
 output of QAT and ensure that the two are kept together for reproducibility.
 
-Another couple of useful features are `strip-exisiting-dbg` and `add-ir-debug`.
-These two can be set from the command line using `--strip-exisiting-dbg` and
-`--add-ir-debug`, respectively. The first, `strip-exisiting-dbg`, removes all
+Another couple of useful features are `strip-existing-dbg` and `add-ir-debug`.
+These two can be set from the command line using `--strip-existing-dbg` and
+`--add-ir-debug`, respectively. The first, `strip-existing-dbg`, removes all
 existing debug information from the loaded modules. The other `add-ir-debug`
 adds debug symbols referring to the LL file itself. This is discussed in
 [detail here](../UsingQAT/DebuggingIR.md).
@@ -195,7 +195,7 @@ exit__1:
 ```
 
 The control logic associated with the loop gives rise to a `phi` node which most
-of todays hardware backends would not be able to handle. However, since hte loop
+of todays hardware backends would not be able to handle. However, since the loop
 is constant in length, we can unroll the loop by using the `unroll-loop`
 parameter:
 
@@ -230,7 +230,7 @@ The generic QIR allows for dynamic qubit allocation as the default way to
 allocate qubits. One of the core differences between simulators and hardware
 backends is how qubits are allocated: While simulators, in theory, can allocate
 as many qubits as need dynamically, hardware backends has a hard limit on the
-number of qubits and futher more, does not implement the necessary logic to
+number of qubits and further more, does not implement the necessary logic to
 perform dynamic management. For this reason, it is necessary to transform
 dynamic qubit management into static allocation in order to make certain QIRs
 compatible with backends that does not implement qubit management.
@@ -278,7 +278,7 @@ entry:
 
 This demo is found in `qir/demo/QubitAllocation`. Note that static qubit
 allocation is not a straight forward task and there are many corner cases for
-which it simply will not work. For instance, recusively allocating qubit where
+which it simply will not work. For instance, recursively allocating qubit where
 recursion stops on a runtime parameter is one case that cannot be mapped. QAT
 does a best effort, but at this point there is no garantuee of correctness.
 
@@ -317,8 +317,8 @@ entry:
 ```
 
 Obviously, this code will not run on the second computer since that machine does
-it makes use of a `z` gate. While we could rewrite the frontend code, the beauti
-of an intermediate represenation is that such tasks can be performed at this
+it makes use of a `z` gate. While we could rewrite the frontend code, the beauty
+of an intermediate representation is that such tasks can be performed at this
 level and hence, the user does not need to worry about hardware compatibility of
 the frontend code.
 
@@ -334,7 +334,7 @@ declare void @__quantum__qis__z__body(%Qubit*) #1
 attributes #1 = { "replaceWith"="soft_z" }
 ```
 
-This states taht if the function `soft_z` is available, replace all calls to
+This states that if the function `soft_z` is available, replace all calls to
 `__quantum__qis__z__body` with `soft_z`. Passing the `main.ll` through QAT does
 not result in any changes. However, adding a `lib.ll` with following code:
 
@@ -411,4 +411,4 @@ Grouping QIS is an experimental adaptor that allows separation of the classical
 operations and pure quantum circuits. In this section we will concentrate on
 showing how to use this feature. If you are interested in the
 
-TODO(tfr): Write this section once the cicruit separation has been revised.
+TODO(tfr): Write this section once the circuit separation has been revised.

--- a/docs/src/UsingQAT/TargetingQIR.md
+++ b/docs/src/UsingQAT/TargetingQIR.md
@@ -14,7 +14,7 @@ Below we list all settings that are used to configure how QAT is running:
 | ------------------------ | ------------------------------------------------------------------------- | ------------- |
 | apply                    | Applies a adaptor to transform the IR in correspondence with the adaptor. | false         |
 | validate                 | Executes the validation procedure.                                        | false         |
-| adaptor-pipeline         | Overrides the adaptor pipleline.                                          |               |
+| adaptor-pipeline         | Overrides the adaptor pipeline.                                           |               |
 | emit-human-readable-llvm | Emits LLVM IR to the standard output.                                     | false         |
 | target-def               | YAML file containing the definition for the target.                       |               |
 | save-config              | YAML file to which the config will be save.                               |               |
@@ -129,7 +129,7 @@ any configuration, its configuration section is empty.
 ### LLVM optimizations - Enables specific LLVM optimizations before and after transformation
 
 The LLVM optimization adaptor runs provides selected LLVM passes to perform
-tranditional optimization tasks such as function inlining, loop unrolling, dead
+traditional optimization tasks such as function inlining, loop unrolling, dead
 code elimination, memory elimination and constant elimination. For each of these
 passes, we provide a number of parameters that allows tuning of the individual
 passes to the extend possible:
@@ -154,7 +154,7 @@ passes to the extend possible:
 
 The purpose of this adaptor is to simplify the IR as much as possible prior to
 targeting the IR. While we have taken great care to ensure that these passes act
-predictably, note that there may be occassions where they produce a different IR
+predictably, note that there may be occasions where they produce a different IR
 than that desired. One such example is promoting if-else statements to switch
 statements where applicable. This is not always desirable since not all backends
 has support for this.
@@ -199,11 +199,11 @@ other patterns. This adaptor only uses LLVM passes at the moment, but could be
 extended using our pattern matching pass to accommodate special requirements.
 Options as the moment are:
 
-| Name                     | Description                                                                                  | Default value |
-| ------------------------ | -------------------------------------------------------------------------------------------- | ------------- |
-| lower-switch             | Lower switch statements.                                                                     | true          |
-| should-eleminate-zext-i1 | Replace zext instruction for i1 with select.                                                 | true          |
-| defer-measurements       | Wether or not measurement and recording functions should be moved to the end of the program. | false         |
+| Name                     | Description                                                                            | Default value |
+| ------------------------ | -------------------------------------------------------------------------------------- | ------------- |
+| lower-switch             | Lower switch statements.                                                               | true          |
+| should-eliminate-zext-i1 | Replace zext instruction for i1 with select.                                           | true          |
+| defer-measurements       | Whether measurement and recording functions should be moved to the end of the program. | false         |
 
 We note that deferred measurements should be moved to the circuit separation
 pass.
@@ -215,7 +215,7 @@ to the replacing function being present in the IR. As an example, imagine a
 backend that implements an X gate but not a Z gate. A QIR that makes use of Z
 gates would not run on said hardware unless we would map Z into the sequence HXH
 where H is the Hadamard gate. The replacement linking adaptor allows us to
-define a software implemention of Z in a separate library and use annotattions
+define a software implementation of Z in a separate library and use annotattions
 on the Z gate function to replace the gate if a software implementation is
 provided.
 
@@ -227,7 +227,7 @@ provided.
 ### Static resource adaptor - Manipulates statically allocated qubits and results
 
 In case of a QIR that uses statically allocated qubits and/or results, the
-static resource adaptor allows manipulation to archieve certain properties. One
+static resource adaptor allows manipulation to achieve certain properties. One
 such property is enforcing consecutive indexing starting 0 and another is the
 ability to ensure that a new qubit is used whenever a reset occurs. The latter
 garantuees that qubits are not reused within the lifetime of the program and is

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,32 +8,24 @@ specific hardware requirements and restrictions.
 Outline:
 
 - [Introduction](#introduction)
-
 - [Quick start](QuickStart/index.md)
-
-  - [Supported systems](QuickStart/index.md#supported-systems)
-  - [Building with Bazel](QuickStart/building-with-bazel.md)
-  - [Building with CMake](QuickStart/building-with-cmake.md)
-  - [Running QAT](QuickStart/running-qat.md)
-
+    - [Supported systems](QuickStart/index.md#supported-systems)
+    - [Building with Bazel](QuickStart/building-with-bazel.md)
+    - [Building with CMake](QuickStart/building-with-cmake.md)
+    - [Running QAT](QuickStart/running-qat.md)
 - Using QAT
-
-  - [Targeting a QIR](UsingQAT/TargetingQIR.md)
-  - [Debugging a QIR](UsingQAT/DebuggingIR.md)
-  - [QAT: Assumptions and Restrictions](UsingQAT/GoalsAndAssumptions.md)
-
+    - [Targeting a QIR](UsingQAT/TargetingQIR.md)
+    - [Debugging a QIR](UsingQAT/DebuggingIR.md)
+    - [QAT: Assumptions and Restrictions](UsingQAT/GoalsAndAssumptions.md)
 - Developer guide
-
-  - [Architecture Overview](DeveloperGuide/ArchitectureOverview.md)
-  - [Writing an adaptor](DeveloperGuide/WritingAdaptor.md)
-  - [Rule based adaptors](DeveloperGuide/WritingRuleTests.md)
-  - [Grouping QIS](DeveloperGuide/LogicSeparation.md)
-
+    - [Architecture Overview](DeveloperGuide/ArchitectureOverview.md)
+    - [Writing an adaptor](DeveloperGuide/WritingAdaptor.md)
+    - [Rule based adaptors](DeveloperGuide/WritingRuleTests.md)
+    - [Grouping QIS](DeveloperGuide/LogicSeparation.md)
 - Additional developer info:
-
-  - [Contributing](../../CONTRIBUTING.md)
-  - [Code quality](DeveloperGuide/CodeQuality.md)
-  - [Developer FAQ](DeveloperGuide/DeveloperFAQ.md)
+    - [Contributing](../../CONTRIBUTING.md)
+    - [Code quality](DeveloperGuide/CodeQuality.md)
+    - [Developer FAQ](DeveloperGuide/DeveloperFAQ.md)
 
 ## Introduction
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -39,7 +39,7 @@ refer to such a subset with constraints as a target. For instance, it is likely
 that early versions of quantum backend will have a limited set of classical
 instructions available. With this in mind, the vendor or user of said backend
 would define a profile that only contains a specified subset. A target consists
-of a set of classical capabililties refered to as a profile and a quantum
+of a set of classical capabililties referred to as a profile and a quantum
 instruction set (QIS). One example of such a target is the base profile with any
 QIS, which only allows function calls and jumps, but no arithmetic, classical
 memory, or classical data types.


### PR DESCRIPTION
Before:

<img width="676" alt="Screenshot 2023-07-03 at 11 26 57 AM" src="https://github.com/qir-alliance/qat/assets/130700862/b414651e-e528-446a-9537-8bc1fbdb2c6c">

After:

<img width="651" alt="Screenshot 2023-07-03 at 11 27 21 AM" src="https://github.com/qir-alliance/qat/assets/130700862/ac934cc4-51fc-4d94-a454-03c8e03c77d5">
