### PR TITLE
Update docs for LLVM 14

### DIFF
--- a/docs/src/QuickStart/building-with-bazel.md
+++ b/docs/src/QuickStart/building-with-bazel.md
@@ -7,7 +7,7 @@ most of the dependencies and arrange them in you workspace such that you do not
 need to checkout submodules or install extra packages. However, following
 external dependencies needs installing in order to use Bazel for building:
 
-- C++ compiler (Clang 13/14 or MSVC 14.20)
+- C++ compiler (Clang 14 or MSVC 14.20)
 - Bazelisk (or Bazel 5.0)
 
 We recommend the usage of Bazelisk as it is a wrapper that automatically

--- a/docs/src/QuickStart/building-with-cmake.md
+++ b/docs/src/QuickStart/building-with-cmake.md
@@ -5,9 +5,9 @@
 It is necessary for you to have the following tools before you get started on
 making a new build from this project:
 
-- C++ compiler (Clang 13 or MSVC)
+- C++ compiler (Clang 14 or MSVC)
 - CMake
-- LLVM 13
+- LLVM 14
 
 If you are compiling and using the command-line tool, these are necessary tools
 regardless of whether you plan to develop the library itself. The build
@@ -30,11 +30,11 @@ Linux build instructions.
 
 ### Prerequisites on macOS
 
-Those using macOS can install CMake and LLVM 13 through the use of a
+Those using macOS can install CMake and LLVM 14 through the use of a
 command-line tool called `brew`, as follows:
 
 ```sh
-brew install cmake llvm@13
+brew install cmake llvm@14
 ```
 
 It should not be necessary to install anything else on top of macOS, since the
@@ -46,21 +46,21 @@ Additionally to CMake, you will also require Clang in order to build on Ubuntu
 20.04. You can accomplish this by following the steps below:
 
 ```sh
-wget -O - https://apt.llvm.org/llvm.sh | bash -s 13
+wget -O - https://apt.llvm.org/llvm.sh | bash -s 14
 apt install cmake
 ```
 
 ### Prerequisites on Ubuntu 22.04
 
-On Ubuntu 22.04, you may need to remove `llvm-14`. If you prefer minimal change
-to your machines configuration, we recommend
+On Ubuntu 22.04, you may need to remove `llvm-13`/`llvm-12`.
+If you prefer minimal change to your machines configuration, we recommend
 [building with Bazel](./building-with-bazel.md).
 
 To prepare your system with the relevant build tools, install `clang`, `cmake`
 and `llvm`
 
 ```sh
-apt install -y clang-13 cmake llvm-13 llvm-13-dev llvm-13-runtime
+apt install -y clang-14 cmake llvm-14
 ```
 
 ## Building QAT using CMake


### PR DESCRIPTION
Looks like support for LLVM 13 was dropped in https://github.com/qir-alliance/qat/pull/156

PS: Unsure if anyone uses Docker, but https://github.com/qir-alliance/qat/blob/main/Docker/CI.Ubuntu22.dockerfile seems outdated too. Also, I couldn't get the `bazelisk` based build to work on my macOS machine.
